### PR TITLE
feat: admin enhancements — dynamic roles, gateway balances, disbursement config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.worktrees/

--- a/src/app/(pages)/(dashboard)/page.tsx
+++ b/src/app/(pages)/(dashboard)/page.tsx
@@ -19,6 +19,8 @@ import { API_ROUTES } from "@/src/lib/routes/endpoints";
 import { Skeleton } from "@/components/ui/skeleton"
 import Link from "next/link";
 import ItemCount from "@/src/components/item-count/itemcount";
+import GatewayBalancesCard from "@/src/components/finance-mgt/GatewayBalancesCard";
+import { GetGatewayBalances } from "@/src/lib/request-handlers/integrationsMgt";
 
 interface Wallet {
   id: string;
@@ -130,6 +132,8 @@ const Home = () => {
   const [range, setRange] = useState<string>("year");
   const [wallet, setWallet] = useState<Wallet | null>(null);
   const { user, isFetching } = useAuth();
+  const { data: gatewayData, isLoading: gatewayLoading } = GetGatewayBalances();
+  const balances = gatewayData?.data?.data || {};
 
   console.log(isFetching ? "Fetching User" : user);
 
@@ -500,6 +504,15 @@ const Home = () => {
                   isIncrease={parseFloat(stats?.totalProperties?.percentageChange) > 0}
                 />
               </Grid>
+              {(user?.role === "ADMIN" || user?.role === "SUPER_ADMIN") && (
+                <Grid size={{ xs: 12 }}>
+                  <GatewayBalancesCard
+                    paystack={balances.paystack || { isAvailable: false, error: "No data" }}
+                    monnify={balances.monnify || { isAvailable: false, error: "No data" }}
+                    isLoading={gatewayLoading}
+                  />
+                </Grid>
+              )}
               <Grid size={{ xs: 12, sm: 12, md: 6, lg: 6 }}>
                 <div className={`p-[20px] h-[270px] border border-[#D9D9D9] rounded-[15px] bg-white shadow-md ${stats?.properties?.length === 0 && "flex items-center justify-center"}`}>
                   {isStatLoading ? (

--- a/src/app/(pages)/(dashboard)/settings/page.tsx
+++ b/src/app/(pages)/(dashboard)/settings/page.tsx
@@ -20,7 +20,7 @@ const settingsOptions = [
   },
   {
     title: "Payments & payouts",
-    description: "Review payments & coupons",
+    description: "Configure payment gateways & payouts",
     route: "/settings/payments-payouts",
     icon: <Icon icon="material-symbols:payments" width="32" height="32" />,
   },

--- a/src/app/(pages)/(dashboard)/settings/payments-payouts/page.tsx
+++ b/src/app/(pages)/(dashboard)/settings/payments-payouts/page.tsx
@@ -1,19 +1,295 @@
+"use client";
+
 import BreadCrumb from "@/src/components/breadcrumb";
+import Button from "@/src/components/button";
+import { Icon } from "@iconify/react";
+import { useState, useEffect } from "react";
+import { toast } from "react-hot-toast";
+import {
+  GetIntegrationConfigs,
+  UpdateIntegrationConfig,
+} from "@/src/lib/request-handlers/integrationsMgt";
+
+const DISBURSEMENT_KEY = "DISBURSEMENT_PROVIDER";
+
+interface ProviderOption {
+  value: string;
+  label: string;
+  description: string;
+  icon: string;
+}
+
+const providerOptions: ProviderOption[] = [
+  {
+    value: "MONNIFY",
+    label: "Monnify",
+    description: "Bank transfer disbursements",
+    icon: "mdi:bank-transfer",
+  },
+  {
+    value: "PAYSTACK",
+    label: "Paystack",
+    description: "Card & bank disbursements",
+    icon: "mdi:credit-card-check",
+  },
+  {
+    value: "FLUTTERWAVE",
+    label: "Flutterwave",
+    description: "Multi-channel disbursements",
+    icon: "mdi:wave",
+  },
+];
+
+const toastStyle = {
+  duration: 3000,
+  style: { maxWidth: "500px", width: "max-content" as const },
+};
 
 const PaymentPayout = () => {
-  return (
-    <>
+  const { data, isLoading, isError } = GetIntegrationConfigs();
+  const mutation = UpdateIntegrationConfig();
+
+  const configs = data?.data?.data ?? [];
+  const disbursementConfig = configs.find(
+    (c: { key: string }) => c.key === DISBURSEMENT_KEY
+  );
+  const currentProvider: string = disbursementConfig?.value ?? "";
+  const updatedAt: string | undefined = disbursementConfig?.updated_at;
+
+  const [selectedProvider, setSelectedProvider] = useState<string>("");
+  const hasChanges = selectedProvider !== "" && selectedProvider !== currentProvider;
+
+  // Sync local state when API data loads
+  useEffect(() => {
+    if (currentProvider) {
+      setSelectedProvider(currentProvider);
+    }
+  }, [currentProvider]);
+
+  const handleSave = () => {
+    if (!hasChanges) return;
+
+    const providerLabel =
+      providerOptions.find((p) => p.value === selectedProvider)?.label ??
+      selectedProvider;
+
+    const confirmed = window.confirm(
+      `Are you sure you want to switch the disbursement provider to ${providerLabel}? This will affect all future withdrawal disbursements.`
+    );
+    if (!confirmed) return;
+
+    mutation.mutate(
+      { key: DISBURSEMENT_KEY, payload: { value: selectedProvider } },
+      {
+        onSuccess: (res) => {
+          toast.success(
+            res?.data?.message ?? "Disbursement provider updated successfully.",
+            toastStyle
+          );
+        },
+        onError: (error: any) => {
+          toast.error(
+            error?.response?.data?.message ??
+              "Failed to update disbursement provider.",
+            toastStyle
+          );
+        },
+      }
+    );
+  };
+
+  const formatDate = (iso: string) => {
+    try {
+      return new Date(iso).toLocaleString("en-NG", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      });
+    } catch {
+      return iso;
+    }
+  };
+
+  // Loading skeleton
+  if (isLoading) {
+    return (
       <div className="p-[30px] mt-10 mb-100 border border-[#D9D9D9] rounded-[15px] bg-white shadow-md min-h-[calc(100vh-150px)]">
         <BreadCrumb
           description=""
-          active="Payment and Payout"
+          active="Payments & Payouts"
           link_one="/settings"
           link_one_name="Settings"
         />
-        Coming Soon
+        <div className="mt-8 animate-pulse">
+          <div className="h-6 bg-gray-200 rounded w-72 mb-4" />
+          <div className="h-4 bg-gray-200 rounded w-96 mb-8" />
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {[1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className="h-32 bg-gray-100 rounded-xl border border-gray-200"
+              />
+            ))}
+          </div>
+        </div>
       </div>
-      ;
-    </>
+    );
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <div className="p-[30px] mt-10 mb-100 border border-[#D9D9D9] rounded-[15px] bg-white shadow-md min-h-[calc(100vh-150px)]">
+        <BreadCrumb
+          description=""
+          active="Payments & Payouts"
+          link_one="/settings"
+          link_one_name="Settings"
+        />
+        <div className="mt-8 flex flex-col items-center justify-center py-20">
+          <Icon
+            icon="mdi:alert-circle-outline"
+            width="48"
+            height="48"
+            className="text-red-400 mb-4"
+          />
+          <p className="text-gray-600 text-lg font-medium">
+            Failed to load integration configurations.
+          </p>
+          <p className="text-gray-400 text-sm mt-1">
+            Please refresh the page or try again later.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-[30px] mt-10 mb-100 border border-[#D9D9D9] rounded-[15px] bg-white shadow-md min-h-[calc(100vh-150px)]">
+      <BreadCrumb
+        description=""
+        active="Payments & Payouts"
+        link_one="/settings"
+        link_one_name="Settings"
+      />
+
+      <div className="mt-8">
+        <h3 className="text-xl font-semibold text-gray-900">
+          Payments & Payouts Configuration
+        </h3>
+        <p className="text-sm text-gray-500 mt-1">
+          Manage payment gateway settings for the platform.
+        </p>
+      </div>
+
+      {/* Disbursement Provider Card */}
+      <div className="mt-8 p-6 border border-[#E4E7EC] rounded-xl bg-white">
+        <div className="flex items-center justify-between flex-wrap gap-3">
+          <div>
+            <h4 className="text-lg font-semibold text-gray-800">
+              Disbursement Provider
+            </h4>
+            <p className="text-sm text-gray-500 mt-1">
+              Select which payment gateway processes withdrawal disbursements.
+            </p>
+          </div>
+          {currentProvider && (
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold bg-green-50 text-green-700 border border-green-200">
+              <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
+              Active: {currentProvider}
+            </span>
+          )}
+        </div>
+
+        {/* Provider Selection Cards */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-6">
+          {providerOptions.map((provider) => {
+            const isSelected = selectedProvider === provider.value;
+            const isCurrent = currentProvider === provider.value;
+
+            return (
+              <button
+                key={provider.value}
+                type="button"
+                onClick={() => setSelectedProvider(provider.value)}
+                className={`
+                  relative flex flex-col items-center gap-3 p-5 rounded-xl border-2 transition-all cursor-pointer text-center
+                  ${
+                    isSelected
+                      ? "border-primary bg-primary/5 shadow-sm"
+                      : "border-[#E4E7EC] bg-white hover:border-gray-300 hover:bg-gray-50"
+                  }
+                `}
+              >
+                {/* Selection indicator */}
+                <div
+                  className={`
+                    absolute top-3 right-3 w-5 h-5 rounded-full border-2 flex items-center justify-center transition-colors
+                    ${
+                      isSelected
+                        ? "border-primary bg-primary"
+                        : "border-gray-300 bg-white"
+                    }
+                  `}
+                >
+                  {isSelected && (
+                    <Icon
+                      icon="mdi:check"
+                      width="14"
+                      height="14"
+                      className="text-white"
+                    />
+                  )}
+                </div>
+
+                <div
+                  className={`
+                    w-12 h-12 rounded-full flex items-center justify-center transition-colors
+                    ${isSelected ? "bg-primary/10 text-primary" : "bg-gray-100 text-gray-500"}
+                  `}
+                >
+                  <Icon icon={provider.icon} width="28" height="28" />
+                </div>
+
+                <div>
+                  <p className="font-semibold text-gray-800">{provider.label}</p>
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    {provider.description}
+                  </p>
+                </div>
+
+                {isCurrent && (
+                  <span className="text-[10px] font-medium text-green-600 bg-green-50 px-2 py-0.5 rounded-full">
+                    Current
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Last updated timestamp */}
+        {updatedAt && (
+          <p className="text-xs text-gray-400 mt-4">
+            Last updated: {formatDate(updatedAt)}
+          </p>
+        )}
+
+        {/* Save Button */}
+        <div className="mt-6 flex justify-end">
+          <div className="w-full sm:w-auto">
+            <Button
+              variant="primaryoutline"
+              buttonSize="medium"
+              color="btnfontprimary"
+              buttonName="Save Changes"
+              disabled={!hasChanges || mutation.isPending}
+              isLoading={mutation.isPending}
+              onClick={handleSave}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/src/components/finance-mgt/GatewayBalancesCard.tsx
+++ b/src/components/finance-mgt/GatewayBalancesCard.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import React from "react";
+import { Icon } from "@iconify/react";
+
+interface GatewayBalance {
+  isAvailable: boolean;
+  available?: number;
+  currency?: string;
+  error?: string;
+}
+
+interface GatewayBalancesCardProps {
+  paystack: GatewayBalance;
+  monnify: GatewayBalance;
+  isLoading?: boolean;
+}
+
+const formatCurrency = (amount: number, currency: string = "NGN") => {
+  return new Intl.NumberFormat("en-NG", {
+    style: "currency",
+    currency,
+  }).format(amount);
+};
+
+const GatewaySection: React.FC<{
+  name: string;
+  icon: string;
+  balance: GatewayBalance;
+}> = ({ name, icon, balance }) => {
+  return (
+    <div className="flex-1 min-w-0">
+      <div className="flex items-center gap-2 mb-3">
+        <Icon icon={icon} className="text-[#028090] text-lg flex-shrink-0" />
+        <span className="text-sm font-medium text-gray-700 truncate">{name}</span>
+        <span
+          className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${
+            balance.isAvailable ? "bg-green-500" : "bg-red-500"
+          }`}
+        />
+      </div>
+      {balance.isAvailable ? (
+        <p className="text-xl sm:text-2xl font-bold text-gray-900">
+          {formatCurrency(balance.available ?? 0, balance.currency)}
+        </p>
+      ) : (
+        <div>
+          <p className="text-sm font-semibold text-red-500">Unavailable</p>
+          {balance.error && (
+            <p className="text-xs text-red-400 mt-1 truncate" title={balance.error}>
+              {balance.error}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const SkeletonSection: React.FC = () => (
+  <div className="flex-1 min-w-0">
+    <div className="flex items-center gap-2 mb-3">
+      <div className="w-5 h-5 rounded bg-gray-200 animate-pulse" />
+      <div className="w-20 h-4 rounded bg-gray-200 animate-pulse" />
+      <div className="w-2.5 h-2.5 rounded-full bg-gray-200 animate-pulse" />
+    </div>
+    <div className="w-36 h-7 rounded bg-gray-200 animate-pulse" />
+  </div>
+);
+
+const GatewayBalancesCard: React.FC<GatewayBalancesCardProps> = ({
+  paystack,
+  monnify,
+  isLoading,
+}) => {
+  return (
+    <div className="border border-[#D9D9D9] rounded-[15px] p-4 sm:p-5 bg-white shadow-md">
+      <div className="flex items-center gap-2 mb-4">
+        <Icon icon="mdi:bank" className="text-[#028090] text-xl" />
+        <h3 className="text-sm font-semibold text-gray-800">Payment Gateway Balances</h3>
+      </div>
+      <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
+        {isLoading ? (
+          <>
+            <SkeletonSection />
+            <div className="hidden sm:block w-px bg-gray-200" />
+            <hr className="sm:hidden border-gray-200" />
+            <SkeletonSection />
+          </>
+        ) : (
+          <>
+            <GatewaySection
+              name="Paystack"
+              icon="mdi:credit-card-outline"
+              balance={paystack}
+            />
+            <div className="hidden sm:block w-px bg-gray-200" />
+            <hr className="sm:hidden border-gray-200" />
+            <GatewaySection
+              name="Monnify"
+              icon="mdi:bank-outline"
+              balance={monnify}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default GatewayBalancesCard;

--- a/src/components/user-management/UserEditForm.tsx
+++ b/src/components/user-management/UserEditForm.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Icon } from '@iconify/react';
+import { GetAssignableRoles } from '@/src/lib/request-handlers/userMgt';
 
 interface UserEditFormProps {
     initialData: {
@@ -28,6 +29,15 @@ const UserEditForm: React.FC<UserEditFormProps> = ({
     isSaving,
     showRoleSelector = true
 }) => {
+    const { data: rolesData, isLoading: rolesLoading } = GetAssignableRoles();
+    const assignableRoles: string[] = rolesData?.data?.data?.assignable_roles || rolesData?.data?.assignable_roles || [];
+
+    const FALLBACK_ROLES = ['GUEST', 'AGENT', 'OWNER', 'ADMIN', 'SUPER_ADMIN'];
+    const roleOptions = assignableRoles.length > 0 ? assignableRoles : FALLBACK_ROLES;
+
+    const formatRoleLabel = (role: string) =>
+        role.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+
     const [formData, setFormData] = useState({
         firstName: initialData.firstName || '',
         lastName: initialData.lastName || '',
@@ -138,11 +148,15 @@ const UserEditForm: React.FC<UserEditFormProps> = ({
                                     value={formData.role}
                                     onChange={e => handleChange('role', e.target.value)}
                                 >
-                                    <option value="GUEST">Guest</option>
-                                    <option value="AGENT">Agent</option>
-                                    <option value="OWNER">Owner</option>
-                                    <option value="ADMIN">Admin</option>
-                                    <option value="SUPER_ADMIN">Super Admin</option>
+                                    {rolesLoading ? (
+                                        <option value="">Loading roles...</option>
+                                    ) : (
+                                        roleOptions.map((role: string) => (
+                                            <option key={role} value={role}>
+                                                {formatRoleLabel(role)}
+                                            </option>
+                                        ))
+                                    )}
                                 </select>
                                 <div className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">
                                     <Icon icon="mdi:chevron-down" width="18" />

--- a/src/components/user-management/UserManagementView.tsx
+++ b/src/components/user-management/UserManagementView.tsx
@@ -77,7 +77,7 @@ interface User {
 }
 
 interface UserManagementViewProps {
-    role: 'GUEST' | 'OWNER' | 'AGENT' | 'ADMIN' | 'SUPER_ADMIN';
+    role: 'GUEST' | 'OWNER' | 'AGENT' | 'ADMIN' | 'SUPER_ADMIN' | 'OPERATIONS_ADMIN' | 'SUPPORT_ADMIN' | 'ANALYST';
     title: string;
     description: string;
     basePath: string; // e.g., "/user-management/guests"

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -7,6 +7,9 @@ export enum KycStatus {
 export enum UserRole {
     SUPER_ADMIN = 'SUPER_ADMIN',
     ADMIN = 'ADMIN',
+    OPERATIONS_ADMIN = 'OPERATIONS_ADMIN',
+    SUPPORT_ADMIN = 'SUPPORT_ADMIN',
+    ANALYST = 'ANALYST',
     GUEST = 'GUEST',
     AGENT = 'AGENT',
     OWNER = 'OWNER',

--- a/src/lib/request-handlers/integrationsMgt.ts
+++ b/src/lib/request-handlers/integrationsMgt.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import axiosRequest from "../api";
+import { API_ROUTES } from "../routes/endpoints";
+
+enum IntegrationsRequestKeys {
+    gatewayBalances = "gatewayBalances",
+    integrationConfigs = "integrationConfigs",
+}
+
+export function GetGatewayBalances() {
+    return useQuery({
+        queryKey: [IntegrationsRequestKeys.gatewayBalances],
+        queryFn: () => axiosRequest.get(API_ROUTES.statistic.gatewayBalances),
+    });
+}
+
+export function GetIntegrationConfigs() {
+    return useQuery({
+        queryKey: [IntegrationsRequestKeys.integrationConfigs],
+        queryFn: () => axiosRequest.get(API_ROUTES.admin.integrations.configs),
+    });
+}
+
+export function UpdateIntegrationConfig() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ key, payload }: { key: string; payload: any }) =>
+            axiosRequest.patch(API_ROUTES.admin.integrations.configByKey(key), payload),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: [IntegrationsRequestKeys.integrationConfigs] });
+        },
+    });
+}

--- a/src/lib/request-handlers/userMgt.ts
+++ b/src/lib/request-handlers/userMgt.ts
@@ -8,6 +8,7 @@ enum UsersRequestKeys {
     createUser = "createUser",
     updateUser = "updateUser",
     deleteUser = "deleteUser",
+    assignableRoles = "assignableRoles",
 }
 
 export function GetAllUsers(page = 1, size = 10, searchQuery = '', role: UserRole | string = '', isVerified: string = '') {
@@ -67,5 +68,12 @@ export function DeleteUser() {
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: [UsersRequestKeys.getAllUsers] });
         },
+    });
+}
+
+export function GetAssignableRoles() {
+    return useQuery({
+        queryKey: [UsersRequestKeys.assignableRoles],
+        queryFn: () => axiosRequest.get(API_ROUTES.admin.users.roles),
     });
 }

--- a/src/lib/routes/endpoints.tsx
+++ b/src/lib/routes/endpoints.tsx
@@ -29,7 +29,12 @@ export const API_ROUTES = {
             base: '/admin/users',
             onboard: '/admin/users/onboard',
             userById: (id: string | number) => `/admin/users/${id}`,
-            userByUuid: (id: string | number) => `/admin/users/${id}`
+            userByUuid: (id: string | number) => `/admin/users/${id}`,
+            roles: '/admin/users/roles',
+        },
+        integrations: {
+            configs: '/admin/integrations/configs',
+            configByKey: (key: string) => `/admin/integrations/configs/${key}`,
         }
     },
     profile: {
@@ -108,7 +113,8 @@ export const API_ROUTES = {
         validate: (paymentId: string) => `/wallets/payments/${paymentId}/validate`,
     },
     statistic: {
-        base: '/stats'
+        base: '/stats',
+        gatewayBalances: '/stats/gateway-balances',
     },
     transactions: {
         base: '/wallets/transactions',


### PR DESCRIPTION
## Summary

Frontend support for the 4 new backend API endpoints added in [api-v1 PR #38](https://github.com/aparte-luxurious-homes/api-v1/pull/38).

- **Dynamic role dropdown**: `UserEditForm` now fetches assignable roles from `GET /api/v1/admin/users/roles` instead of hardcoded options. ADMIN users only see roles they're allowed to assign. Falls back to hardcoded list if API is unavailable. Added `OPERATIONS_ADMIN`, `SUPPORT_ADMIN`, `ANALYST` to `UserRole` enum.
- **Gateway balances widget**: New `GatewayBalancesCard` on the dashboard showing Paystack and Monnify merchant account balances (admin-only). Handles loading, error, and unavailable states with proper currency formatting.
- **Disbursement provider config**: Replaced "Coming Soon" placeholder in Settings > Payments & Payouts with a real configuration page. Three selectable radio-cards (Monnify, Paystack, Flutterwave) with save confirmation and toast feedback.

## New files
- `src/components/finance-mgt/GatewayBalancesCard.tsx`
- `src/lib/request-handlers/integrationsMgt.ts`

## Test plan
- [ ] Verify role dropdown shows only roles the current admin can assign
- [ ] Verify ADMIN cannot see ADMIN/SUPER_ADMIN in dropdown
- [ ] Verify gateway balances card shows on dashboard for admin users
- [ ] Verify gateway balances handles unavailable providers gracefully
- [ ] Verify Settings > Payments & Payouts shows disbursement provider config
- [ ] Verify switching provider saves correctly with toast feedback
- [ ] Verify all existing pages still render without errors