### PR TITLE
feat(owner-reports): implement owner reporting suite (statements & booking reports)

### DIFF
--- a/src/app/(pages)/(dashboard)/reports/owner-reports/page.tsx
+++ b/src/app/(pages)/(dashboard)/reports/owner-reports/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import React, { useState } from "react";
+import BookingReportsTab from "@/src/components/reports-mgt/BookingReportsTab";
+import StatementsTab from "@/src/components/reports-mgt/StatementsTab";
+import { InfoIcon } from "lucide-react";
+
+type TabId = 'reports' | 'statements';
+
+export default function OwnerReportsPage() {
+    const [activeTab, setActiveTab] = useState<TabId>('reports');
+
+    const tabs = [
+        { id: 'reports', label: 'Booking Reports' },
+        { id: 'statements', label: 'Statements' },
+    ] as const;
+
+    return (
+        <div className="flex flex-col gap-6 p-4 md:p-8">
+            <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+                <div>
+                    <h1 className="text-2xl font-bold text-gray-900">
+                        {activeTab === 'reports' ? 'Reports' : 'Statements'}
+                    </h1>
+                    <p className="text-sm text-gray-500 mt-1">
+                        {activeTab === 'reports' 
+                            ? 'Generate and download reports of your bookings. Use filters below to customize your report.'
+                            : 'View and download your monthly statements. Statements are automatically generated on the 1st of each month for the previous month\'s activity.'}
+                    </p>
+                </div>
+                
+                <button className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-primary bg-white border border-gray-200 rounded-full shadow-sm hover:bg-gray-50 transition-colors shrink-0">
+                    <InfoIcon className="w-4 h-4" />
+                    How {activeTab === 'reports' ? 'reports' : 'statements'} work
+                </button>
+            </div>
+
+            {/* Custom Tab Navigation */}
+            <div className="border-b border-gray-200">
+                <nav className="-mb-px flex space-x-8" aria-label="Tabs">
+                    {tabs.map((tab) => {
+                        const isActive = activeTab === tab.id;
+                        return (
+                            <button
+                                key={tab.id}
+                                onClick={() => setActiveTab(tab.id)}
+                                className={`
+                                    whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm transition-colors
+                                    ${isActive 
+                                        ? 'border-primary text-primary' 
+                                        : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                                    }
+                                `}
+                                aria-current={isActive ? 'page' : undefined}
+                            >
+                                {tab.label}
+                            </button>
+                        );
+                    })}
+                </nav>
+            </div>
+
+            {/* Tab Content */}
+            <div className="mt-4">
+                {activeTab === 'reports' && <BookingReportsTab />}
+                {/* StatementsTab only mounts when activeTab === 'statements', ensuring data isn't fetched prematurely */}
+                {activeTab === 'statements' && <StatementsTab />}
+            </div>
+        </div>
+    );
+}

--- a/src/components/reports-mgt/BookingReportsTab.tsx
+++ b/src/components/reports-mgt/BookingReportsTab.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import React, { useState } from "react";
+import { downloadReportFile } from "@/src/lib/request-handlers/reportsMgt";
+import { GetAllProperties } from "@/src/lib/request-handlers/propertyMgt";
+import { API_ROUTES } from "@/src/lib/routes/endpoints";
+import toast from "react-hot-toast";
+import { FiDownload } from "react-icons/fi";
+import Spinner from "@/src/components/ui/Spinner";
+import { UserRole } from "@/src/lib/enums";
+import { useAuth } from "@/src/hooks/useAuth";
+
+export default function BookingReportsTab() {
+    const { user } = useAuth();
+    const [startDate, setStartDate] = useState("");
+    const [endDate, setEndDate] = useState("");
+    const [propertyId, setPropertyId] = useState("");
+    const [status, setStatus] = useState("");
+    const [paymentMethod, setPaymentMethod] = useState("");
+    
+    const [exportingFormat, setExportingFormat] = useState<string | null>(null);
+
+    // Fetch properties for the dropdown
+    const { data: propertiesData } = GetAllProperties(1, 100, "", user?.role as UserRole, user?.id);
+    const properties = propertiesData?.data?.data?.items || [];
+
+    const handleExport = async (formatType: 'pdf' | 'csv' | 'xlsx') => {
+        try {
+            setExportingFormat(formatType);
+            
+            // Build query params
+            const queryParams = new URLSearchParams({ format: formatType });
+            if (startDate) queryParams.append("start_date", startDate);
+            if (endDate) queryParams.append("end_date", endDate);
+            if (propertyId) queryParams.append("property_id", propertyId);
+            if (status) queryParams.append("status", status);
+            if (paymentMethod) queryParams.append("payment_method", paymentMethod);
+            
+            const url = `${API_ROUTES.reports.bookings.export}?${queryParams.toString()}`;
+            const filename = `Booking_Report_${new Date().getTime()}.${formatType}`;
+            
+            await downloadReportFile(url, formatType, filename);
+            toast.success(`${formatType.toUpperCase()} export downloaded successfully`);
+        } catch (err: any) {
+            console.error("Export failed:", err);
+            const errorMsg = err?.response?.data?.message || err?.message || "Failed to export report";
+            toast.error(errorMsg);
+        } finally {
+            setExportingFormat(null);
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <div className="bg-white rounded-lg border border-gray-200 p-6">
+                <div className="mb-6">
+                    <h2 className="text-xl font-bold text-gray-800">Generate Booking Report</h2>
+                    <p className="text-sm text-gray-500">Customize your report using the filters below.</p>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+                    {/* Date Range */}
+                    <div className="space-y-1.5">
+                        <label className="text-sm font-medium text-gray-700">Start Date</label>
+                        <input 
+                            type="date" 
+                            value={startDate}
+                            onChange={(e) => setStartDate(e.target.value)}
+                            className="w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary sm:text-sm"
+                        />
+                    </div>
+                    <div className="space-y-1.5">
+                        <label className="text-sm font-medium text-gray-700">End Date</label>
+                        <input 
+                            type="date" 
+                            value={endDate}
+                            onChange={(e) => setEndDate(e.target.value)}
+                            className="w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary sm:text-sm"
+                        />
+                    </div>
+
+                    {/* Property Filter */}
+                    <div className="space-y-1.5">
+                        <label className="text-sm font-medium text-gray-700">Property</label>
+                        <select 
+                            value={propertyId}
+                            onChange={(e) => setPropertyId(e.target.value)}
+                            className="w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary sm:text-sm"
+                        >
+                            <option value="">All Properties</option>
+                            {properties.map((p: any) => (
+                                <option key={p.id} value={p.id}>{p.name}</option>
+                            ))}
+                        </select>
+                    </div>
+
+                    {/* Status Filter */}
+                    <div className="space-y-1.5">
+                        <label className="text-sm font-medium text-gray-700">Booking Status</label>
+                        <select 
+                            value={status}
+                            onChange={(e) => setStatus(e.target.value)}
+                            className="w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary sm:text-sm"
+                        >
+                            <option value="">All Statuses</option>
+                            <option value="PENDING">Pending</option>
+                            <option value="CONFIRMED">Confirmed</option>
+                            <option value="CANCELLED">Cancelled</option>
+                            <option value="COMPLETED">Completed</option>
+                        </select>
+                    </div>
+
+                    {/* Payment Method Filter */}
+                    <div className="space-y-1.5">
+                        <label className="text-sm font-medium text-gray-700">Payment Method</label>
+                        <select 
+                            value={paymentMethod}
+                            onChange={(e) => setPaymentMethod(e.target.value)}
+                            className="w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-primary focus:border-primary sm:text-sm"
+                        >
+                            <option value="">All Payment Methods</option>
+                            <option value="PAYSTACK">Paystack</option>
+                            <option value="TRANSFER">Bank Transfer</option>
+                            <option value="CASH">Cash</option>
+                            <option value="POS">POS</option>
+                        </select>
+                    </div>
+                </div>
+
+                {/* Actions */}
+                <div className="flex flex-wrap items-center gap-4 pt-6 border-t border-gray-100">
+                    <span className="text-sm font-medium text-gray-700 mr-2">Export As:</span>
+                    
+                    <button 
+                        onClick={() => handleExport('pdf')}
+                        disabled={!!exportingFormat}
+                        className="flex items-center gap-2 px-4 py-2 bg-white border border-red-200 text-red-700 rounded-md shadow-sm hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 transition-colors text-sm font-medium"
+                    >
+                        {exportingFormat === 'pdf' ? <Spinner className="w-4 h-4 text-red-700" /> : <FiDownload className="w-4 h-4" />}
+                        Export to PDF
+                    </button>
+                    
+                    <button 
+                        onClick={() => handleExport('csv')}
+                        disabled={!!exportingFormat}
+                        className="flex items-center gap-2 px-4 py-2 bg-white border border-green-200 text-green-700 rounded-md shadow-sm hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:opacity-50 transition-colors text-sm font-medium"
+                    >
+                        {exportingFormat === 'csv' ? <Spinner className="w-4 h-4 text-green-700" /> : <FiDownload className="w-4 h-4" />}
+                        Export to CSV
+                    </button>
+                    
+                    <button 
+                        onClick={() => handleExport('xlsx')}
+                        disabled={!!exportingFormat}
+                        className="flex items-center gap-2 px-4 py-2 bg-white border border-blue-200 text-blue-700 rounded-md shadow-sm hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 transition-colors text-sm font-medium"
+                    >
+                        {exportingFormat === 'xlsx' ? <Spinner className="w-4 h-4 text-blue-700" /> : <FiDownload className="w-4 h-4" />}
+                        Export to Excel (.xlsx)
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/reports-mgt/StatementsTab.tsx
+++ b/src/components/reports-mgt/StatementsTab.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import React, { useState } from "react";
+import { GetStatements, downloadReportFile } from "@/src/lib/request-handlers/reportsMgt";
+import { API_ROUTES } from "@/src/lib/routes/endpoints";
+import toast from "react-hot-toast";
+import { FiDownload } from "react-icons/fi";
+import { format } from "date-fns";
+import TablePagination from "@/src/components/TablePagination";
+import Spinner from "@/src/components/ui/Spinner";
+
+interface IStatement {
+    year: number;
+    month: number;
+    status: string;
+    delivered_at: string;
+    bookings_count?: number;
+    gross_revenue?: number;
+    net_to_wallet?: number;
+}
+
+export default function StatementsTab() {
+    const { data: statementsData, isLoading, error } = GetStatements();
+    const statements: IStatement[] = statementsData?.data?.data || [];
+    
+    const [downloadingId, setDownloadingId] = useState<string | null>(null);
+
+    const [page, setPage] = useState(0);
+    const [rowsPerPage, setRowsPerPage] = useState(10);
+
+    const handleChangePage = (event: unknown, newPage: number) => {
+        setPage(newPage);
+    };
+
+    const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setRowsPerPage(parseInt(event.target.value, 10));
+        setPage(0);
+    };
+
+    const handleDownload = async (year: number, month: number, formatType: 'pdf' | 'csv') => {
+        const id = `${year}-${month}-${formatType}`;
+        try {
+            setDownloadingId(id);
+            const url = API_ROUTES.reports.statements.download(year, month);
+            
+            // Format month name for filename
+            const date = new Date(year, month - 1);
+            const monthName = format(date, "MMMM");
+            const filename = `Statement_${monthName}_${year}.${formatType}`;
+            
+            await downloadReportFile(url, formatType, filename);
+            toast.success(`${formatType.toUpperCase()} downloaded successfully`);
+        } catch (err: any) {
+            console.error("Download failed:", err);
+            const errorMsg = err?.response?.data?.message || err?.message || "Failed to download statement";
+            toast.error(errorMsg);
+        } finally {
+            setDownloadingId(null);
+        }
+    };
+
+    const paginatedStatements = statements.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
+
+    return (
+        <div className="space-y-6">
+            <div className="bg-white rounded-lg border border-gray-200 p-6">
+                <div className="flex justify-between items-center mb-4">
+                    <div>
+                        <h2 className="text-xl font-bold text-gray-800">Past Statements</h2>
+                        <p className="text-sm text-gray-500">Download statements for any past month.</p>
+                    </div>
+                </div>
+
+                {isLoading ? (
+                    <div className="flex justify-center py-10">
+                        <Spinner className="w-8 h-8 text-primary" />
+                    </div>
+                ) : error ? (
+                    <div className="text-red-500 py-4">Failed to load statements. Please try again later.</div>
+                ) : (
+                    <div className="overflow-x-auto">
+                        <table className="w-full text-left text-sm whitespace-nowrap">
+                            <thead className="bg-gray-50 text-gray-600 font-semibold border-b border-gray-200">
+                                <tr>
+                                    <th className="px-6 py-4 rounded-tl-lg">Month</th>
+                                    <th className="px-6 py-4">Status</th>
+                                    <th className="px-6 py-4">Delivered On</th>
+                                    <th className="px-6 py-4 rounded-tr-lg text-right">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-gray-100">
+                                {paginatedStatements.length > 0 ? (
+                                    paginatedStatements.map((stmt, index) => {
+                                        const date = new Date(stmt.year, stmt.month - 1);
+                                        const monthYear = format(date, "MMMM yyyy");
+                                        const deliveredDate = stmt.delivered_at ? format(new Date(stmt.delivered_at), "d MMM yyyy, hh:mm a") : "—";
+                                        
+                                        return (
+                                            <tr key={`${stmt.year}-${stmt.month}-${index}`} className="hover:bg-gray-50/50 transition-colors">
+                                                <td className="px-6 py-4 font-medium text-gray-900">{monthYear}</td>
+                                                <td className="px-6 py-4">
+                                                    <span className={`px-2.5 py-1 text-xs font-medium rounded-full ${
+                                                        stmt.status === 'DELIVERED' ? 'bg-green-100 text-green-700' : 
+                                                        stmt.status === 'FAILED' ? 'bg-red-100 text-red-700' : 
+                                                        'bg-gray-100 text-gray-700'
+                                                    }`}>
+                                                        {stmt.status || 'Pending'}
+                                                    </span>
+                                                </td>
+                                                <td className="px-6 py-4 text-gray-500">{deliveredDate}</td>
+                                                <td className="px-6 py-4 text-right">
+                                                    <div className="flex items-center justify-end gap-3">
+                                                        <button 
+                                                            onClick={() => handleDownload(stmt.year, stmt.month, 'pdf')}
+                                                            disabled={downloadingId === `${stmt.year}-${stmt.month}-pdf`}
+                                                            className="flex items-center gap-1.5 text-primary hover:text-primary/80 disabled:opacity-50 text-sm font-medium transition-colors"
+                                                        >
+                                                            {downloadingId === `${stmt.year}-${stmt.month}-pdf` ? (
+                                                                <Spinner className="w-4 h-4" />
+                                                            ) : (
+                                                                <FiDownload className="w-4 h-4" />
+                                                            )}
+                                                            PDF
+                                                        </button>
+                                                        <span className="text-gray-300">|</span>
+                                                        <button 
+                                                            onClick={() => handleDownload(stmt.year, stmt.month, 'csv')}
+                                                            disabled={downloadingId === `${stmt.year}-${stmt.month}-csv`}
+                                                            className="flex items-center gap-1.5 text-primary hover:text-primary/80 disabled:opacity-50 text-sm font-medium transition-colors"
+                                                        >
+                                                            {downloadingId === `${stmt.year}-${stmt.month}-csv` ? (
+                                                                <Spinner className="w-4 h-4" />
+                                                            ) : (
+                                                                <FiDownload className="w-4 h-4" />
+                                                            )}
+                                                            CSV
+                                                        </button>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })
+                                ) : (
+                                    <tr>
+                                        <td colSpan={4} className="px-6 py-10 text-center text-gray-500">
+                                            No statements available.
+                                        </td>
+                                    </tr>
+                                )}
+                            </tbody>
+                        </table>
+                        
+                        {statements.length > 0 && (
+                            <TablePagination
+                                component="div"
+                                count={statements.length}
+                                page={page}
+                                onPageChange={handleChangePage}
+                                rowsPerPage={rowsPerPage}
+                                onRowsPerPageChange={handleChangeRowsPerPage}
+                                rowsPerPageOptions={[10, 25, 50]}
+                            />
+                        )}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/lib/request-handlers/reportsMgt.ts
+++ b/src/lib/request-handlers/reportsMgt.ts
@@ -1,0 +1,65 @@
+import { useQuery } from "@tanstack/react-query";
+import axiosRequest from "../api";
+import { API_ROUTES } from "../routes/endpoints";
+
+export enum ReportsRequestKeys {
+    statements = "getStatements",
+}
+
+export function GetStatements() {
+    return useQuery({
+        queryKey: [ReportsRequestKeys.statements],
+        queryFn: () => axiosRequest.get(API_ROUTES.reports.statements.base),
+        refetchOnWindowFocus: true,
+    });
+}
+
+/**
+ * Utility to download a file from a given URL as a blob
+ */
+export async function downloadReportFile(url: string, format: string, defaultFilename: string) {
+    try {
+        const response = await axiosRequest.get(url, {
+            params: { format },
+            responseType: 'blob', // Important: tells axios to handle binary data
+        });
+
+        // Determine content type from response or fallback
+        const contentType = response.headers['content-type'] || 
+                            (format === 'pdf' ? 'application/pdf' : 
+                             format === 'xlsx' ? 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' :
+                             'text/csv');
+
+        const blob = new Blob([response.data], { type: contentType });
+        const downloadUrl = window.URL.createObjectURL(blob);
+        
+        const link = document.createElement('a');
+        link.href = downloadUrl;
+        
+        // Try to get filename from content-disposition header if available
+        let filename = defaultFilename;
+        const disposition = response.headers['content-disposition'];
+        if (disposition && disposition.indexOf('attachment') !== -1) {
+            const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+            const matches = filenameRegex.exec(disposition);
+            if (matches != null && matches[1]) { 
+                filename = matches[1].replace(/['"]/g, '');
+            }
+        }
+
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        
+        // Cleanup
+        setTimeout(() => {
+            document.body.removeChild(link);
+            window.URL.revokeObjectURL(downloadUrl);
+        }, 100);
+
+        return true;
+    } catch (error) {
+        console.error("Error downloading file:", error);
+        throw error;
+    }
+}

--- a/src/lib/routes/endpoints.tsx
+++ b/src/lib/routes/endpoints.tsx
@@ -191,6 +191,15 @@ export const API_ROUTES = {
         stats: '/referrals/stats',
         list: '/referrals/list',
     },
+    reports: {
+        statements: {
+            base: '/reports/me/statements',
+            download: (year: string | number, month: string | number) => `/reports/me/statements/${year}/${month}/download`,
+        },
+        bookings: {
+            export: '/reports/bookings/export',
+        }
+    }
 };
 
 

--- a/src/lib/routes/nav_links.tsx
+++ b/src/lib/routes/nav_links.tsx
@@ -263,7 +263,7 @@ export const NAV_LINKS: ILink[] = [
         pathName: 'reports',
         link: PAGE_ROUTES.dashboard.reports.agentPerformance,
         icon: <FinancialsIcon className={"w-5"} color={"white"} />,
-        allow: [UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.OPERATIONS_ADMIN, UserRole.ANALYST],
+        allow: [UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.OPERATIONS_ADMIN, UserRole.ANALYST, UserRole.OWNER],
         secondary: true,
         children: [
             {
@@ -271,6 +271,12 @@ export const NAV_LINKS: ILink[] = [
                 pathName: 'agent-performance',
                 link: PAGE_ROUTES.dashboard.reports.agentPerformance,
                 allow: [UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.OPERATIONS_ADMIN, UserRole.ANALYST],
+            },
+            {
+                name: 'Owner Reports',
+                pathName: 'owner-reports',
+                link: PAGE_ROUTES.dashboard.reports.ownerReports,
+                allow: [UserRole.OWNER, UserRole.ADMIN, UserRole.SUPER_ADMIN],
             },
         ]
     },

--- a/src/lib/routes/page_routes.tsx
+++ b/src/lib/routes/page_routes.tsx
@@ -117,6 +117,7 @@ export const PAGE_ROUTES = {
         reports: {
             base: '/reports',
             agentPerformance: '/reports/agent-performance',
+            ownerReports: '/reports/owner-reports',
         },
         wallet: {
             base: '/wallet',


### PR DESCRIPTION
## Overview
This PR implements the new **Owner Reporting Suite** within the Admin Dashboard. It introduces a unified reporting interface for owners, allowing them to download automated monthly statements and run custom, ad-hoc booking reports.

## Key Changes
* **Routing & Sidebar Updates:** 
  * Added the `reports/owner-reports` route.
  * Updated `nav_links.tsx` to display the "Owner Reports" section in the sidebar for users with the `OWNER` role.
* **Unified Reports Page (`OwnerReportsPage`):** 
  * Created a parent page wrapper featuring custom UI tabs to toggle between "Booking Reports" and "Statements". 
  * Integrated lazy mounting to ensure data (e.g., Statements) is only fetched when its specific tab is active.
* **API Integration & File Export (`reportsMgt.ts`):** 
  * Added TanStack Query hooks for `GetStatements`.
  * Implemented a robust `downloadReportFile` utility that hooks into our authenticated Axios instance. It parses the blob response and `content-disposition` headers to seamlessly handle native file downloads across PDF, CSV, and Excel formats.
* **Booking Reports Tab:** 
  * Built a dynamic query form allowing owners to filter by Date Range, Property, Status, and Payment Method.
  * Connected filters to the `GET /reports/bookings/export` endpoint with format selection (PDF, CSV, XLSX).
* **Statements Tab:** 
  * Designed a data table (with `TablePagination`) to list monthly statements.
  * Added inline row actions to export past statements in PDF or CSV formats.

## Testing & Verification
* Verified routing and role-based access.
* Verified that tab switching handles mounting and query execution correctly.
* Verified blob data download mechanisms and filename parsing.