### PR TITLE
fix(audit): A4 — mask NIN/BVN in verification view

### DIFF
--- a/src/components/properties-mgt/manage-verifications/VerificationDetails.tsx
+++ b/src/components/properties-mgt/manage-verifications/VerificationDetails.tsx
@@ -7,7 +7,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Navigation, Autoplay } from 'swiper/modules';
 import { IoLocationOutline } from 'react-icons/io5';
-import { formatDate } from '@/src/lib/utils';
+import { formatDate, maskId } from '@/src/lib/utils';
 import { VerificationBadge } from '../../badge';
 import { CalendarIcon } from '../../icons';
 import { IProperty, IPropertyVerification, PropertyVerificationStatus } from '../types';
@@ -862,11 +862,11 @@ export default function VerificationDetails({
                                 </div>
                                 <div>
                                     <p className="text-xs text-zinc-500 mb-1">BVN</p>
-                                    <p className="text-sm font-medium text-zinc-800">{property.owner.profile.bvn || 'Not provided'}</p>
+                                    <p data-clarity-mask="true" className="text-sm font-medium text-zinc-800">{property.owner.profile.bvn ? maskId(property.owner.profile.bvn) : 'Not provided'}</p>
                                 </div>
                                 <div>
                                     <p className="text-xs text-zinc-500 mb-1">NIN</p>
-                                    <p className="text-sm font-medium text-zinc-800">{property.owner.profile.nin || 'Not provided'}</p>
+                                    <p data-clarity-mask="true" className="text-sm font-medium text-zinc-800">{property.owner.profile.nin ? maskId(property.owner.profile.nin) : 'Not provided'}</p>
                                 </div>
                                 {property.owner.profile.kycProvider && (
                                     <div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,6 +20,21 @@ export function areArraysEqual(arr1: any[], arr2: any[]): boolean {
   return arr1.sort().toString() === arr2.sort().toString();
 }
 
+/**
+ * Masks a sensitive identifier (e.g. NIN/BVN) for display, revealing only the
+ * first 2 and last 2 characters. Mirrors the masking already used in the KYC
+ * review panel so PII is never rendered in clear text in the admin UI.
+ */
+export function maskId(value: string | null | undefined): string {
+  if (!value) return "";
+  if (value.length <= 4) return value;
+  return (
+    value.slice(0, 2) +
+    "•".repeat(Math.max(0, value.length - 4)) +
+    value.slice(-2)
+  );
+}
+
 export function formatDate(dateString: string): string {
   if (!dateString) return "--/--";
   const date = new Date(dateString);


### PR DESCRIPTION
## Finding A4 (MEDIUM) — Raw NIN/BVN rendered unmasked in admin

**Severity:** MEDIUM
**Repo:** `admin-dashboard`
**File:** `src/components/properties-mgt/manage-verifications/VerificationDetails.tsx` (Owner & KYC tab)

### Problem
In the property verification details view, the owner's `profile.bvn` and `profile.nin` were printed in clear text. Elsewhere in the codebase (`src/components/user-management/KycReviewPanel.tsx`) these sensitive identifiers are already masked (first 2 + last 2 characters revealed). This view leaked the full values to anyone with access to the verification screen, and to Microsoft Clarity session replay.

### What changed
- **`VerificationDetails.tsx`** — BVN and NIN render values are now wrapped in `maskId(...)`, so only the first 2 and last 2 characters are shown (e.g. `12•••••••89`). The `'Not provided'` fallback is preserved.
- Added `data-clarity-mask="true"` to the BVN and NIN elements so Microsoft Clarity session replay cannot capture the values (defense-in-depth — the codebase already uses this attribute for sensitive data, e.g. merchant balances in `layouts/dashboard.tsx`).
- **`src/lib/utils.ts`** — `maskId()` was promoted into the shared utils module (the file `VerificationDetails.tsx` already imports `formatDate` from) and exported, **so the masking logic is NOT duplicated**. `KycReviewPanel.tsx` was intentionally left untouched (its local copy still works; no regression risk).

This is a **presentational change only** — no logic, data-fetching, or type changes. Minimal diff (2 files, +18/−3).

### Note on scope
The finding asked to "import the SAME helper (do not duplicate the function)." In the current code, `maskId` is a **private, non-exported local function** inside `KycReviewPanel.tsx`, so there was no shared helper to import. To honor "do not duplicate" without rewriting `KycReviewPanel.tsx`, the helper was added as a new **exported** function in the existing shared `src/lib/utils.ts` (purely additive — no existing code modified) and imported into `VerificationDetails.tsx`. A follow-up could re-point `KycReviewPanel.tsx` to the shared helper to remove its now-redundant local copy, but that is out of scope for this single-finding fix.

### How validated
- `npm install` — OK (required `--legacy-peer-deps` due to a **pre-existing** peer conflict: `react-loader-spinner@6.1.6` does not declare React 19 support; unrelated to this change).
- `npm run lint` (`next lint`) — **pass** (exit 0). Only pre-existing warnings in unrelated files; none from the changed files.
- `npm run build` (`next build`) — **pass** (exit 0). The verification route `/property-management/all-properties/[propertyId]/verifications/[verificationId]` compiled cleanly.

### Residual risk
- **No unit-test infrastructure** in `admin-dashboard` (no test framework configured) — change verified via build/lint and code review only. No tests were added (out of envelope).
- `data-clarity-mask` is a client-side defense. For full protection, Microsoft Clarity should **also** be configured in **"Mask" mode server-side** so PII is masked regardless of per-element attributes.
- `package-lock.json` / `yarn.lock` were modified locally by the `--legacy-peer-deps` install but were **intentionally not committed** — this PR contains only the two source-file changes.

---

Authored by remediation agent — requires human review. **Do not merge without review.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
