### PR TITLE
feat(finance): Reverse Withdrawal action for stuck/failed payouts

### DIFF
--- a/src/components/finance-mgt/modals/ReverseWithdrawalModal.tsx
+++ b/src/components/finance-mgt/modals/ReverseWithdrawalModal.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState } from "react";
+import Modal from "../../modal/Modal";
+import { ReverseWithdrawal } from "@/src/lib/request-handlers/financeMgt";
+import { toast } from "react-hot-toast";
+
+interface ReverseWithdrawalModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    transactionId: string;
+    amount: string | number;
+    currency: string;
+    walletId: string;
+    email: string;
+    /** Current status of the withdrawal — shown for context. */
+    status?: string;
+}
+
+export function ReverseWithdrawalModal({
+    isOpen,
+    onClose,
+    transactionId,
+    amount,
+    currency,
+    walletId,
+    email,
+    status,
+}: ReverseWithdrawalModalProps) {
+    const reverseWithdrawal = ReverseWithdrawal();
+    const [reason, setReason] = useState("");
+    const [skipProviderCheck, setSkipProviderCheck] = useState(false);
+
+    const reasonValid = reason.trim().length >= 3;
+
+    const reset = () => {
+        setReason("");
+        setSkipProviderCheck(false);
+    };
+
+    const handleReverse = () => {
+        if (!reasonValid) {
+            toast.error("Please enter a reason (at least 3 characters).");
+            return;
+        }
+
+        const payload = {
+            transaction_id: transactionId,
+            reason: reason.trim(),
+            skip_provider_check: skipProviderCheck,
+        };
+
+        reverseWithdrawal.mutate(
+            {
+                walletId,
+                payload,
+            },
+            {
+                onSuccess: () => {
+                    toast.success("Withdrawal reversed and funds returned to wallet");
+                    reset();
+                    onClose();
+                },
+                onError: (err: any) => {
+                    toast.error(
+                        err?.response?.data?.message ||
+                        err?.response?.data?.detail?.message ||
+                        err?.response?.data?.detail ||
+                        "Failed to reverse withdrawal"
+                    );
+                },
+            }
+        );
+    };
+
+    const handleClose = () => {
+        reset();
+        onClose();
+    };
+
+    const content = (
+        <div className="text-left space-y-6">
+            <div className="p-4 bg-amber-50 rounded-lg border border-amber-100">
+                <p className="text-sm text-gray-600">
+                    You are reversing a withdrawal of{" "}
+                    <span className="font-bold text-gray-900">
+                        {currency} {Number(amount).toLocaleString()}
+                    </span>{" "}
+                    for user <span className="font-medium text-gray-900">{email}</span>
+                    {status ? (
+                        <>
+                            {" "}
+                            (currently <span className="font-medium text-gray-900">{status}</span>)
+                        </>
+                    ) : null}
+                    .
+                </p>
+                <p className="text-xs text-gray-500 mt-2">
+                    Use this only when the payout did <span className="font-semibold">not</span>{" "}
+                    reach the recipient (provider failed it, or the OTP authorization expired).
+                    The amount and any transfer fee are refunded to the user&apos;s wallet.
+                </p>
+            </div>
+
+            <div className="space-y-2">
+                <label className="text-sm font-medium text-gray-700">
+                    Reason for reversal <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                    value={reason}
+                    onChange={(e) => setReason(e.target.value)}
+                    placeholder="e.g. Provider failed the transfer / OTP window expired — ops confirmed payout did not settle."
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-amber-200 focus:border-amber-400 outline-none resize-none"
+                    rows={3}
+                />
+                {!reasonValid && reason.length > 0 && (
+                    <p className="text-xs text-red-500">Reason must be at least 3 characters.</p>
+                )}
+            </div>
+
+            <label className="flex items-start gap-3 p-3 rounded-lg border border-gray-200 bg-gray-50 cursor-pointer">
+                <input
+                    type="checkbox"
+                    checked={skipProviderCheck}
+                    onChange={(e) => setSkipProviderCheck(e.target.checked)}
+                    className="mt-0.5 h-4 w-4 rounded border-gray-300 text-amber-600 focus:ring-amber-400"
+                />
+                <span className="text-xs text-gray-600">
+                    <span className="font-semibold text-gray-800">
+                        Skip provider verification
+                    </span>{" "}
+                    — bypass the automatic check with the provider. Only tick this if you have
+                    already confirmed with the provider that the payout will{" "}
+                    <span className="font-semibold">not</span> settle. Otherwise, leave it off and
+                    the system will refuse to refund a payout that actually succeeded.
+                </span>
+            </label>
+
+            <div className="flex justify-end gap-3 pt-4 border-t border-gray-100">
+                <button
+                    onClick={handleClose}
+                    disabled={reverseWithdrawal.isPending}
+                    className="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                >
+                    Cancel
+                </button>
+                <button
+                    onClick={handleReverse}
+                    disabled={reverseWithdrawal.isPending || !reasonValid}
+                    className="px-4 py-2 bg-amber-600 text-white rounded-lg text-sm font-medium hover:bg-amber-700 transition-colors disabled:opacity-50 flex items-center gap-2"
+                >
+                    {reverseWithdrawal.isPending ? "Processing..." : "Reverse & Refund"}
+                </button>
+            </div>
+        </div>
+    );
+
+    return (
+        <Modal
+            isOpen={isOpen}
+            onClose={handleClose}
+            title="Reverse Withdrawal"
+            content={content}
+        />
+    );
+}

--- a/src/components/transactions/TransactionDetailView.tsx
+++ b/src/components/transactions/TransactionDetailView.tsx
@@ -13,6 +13,7 @@ import { Icon } from "@iconify/react";
 import { ApproveRefundModal } from "@/src/components/finance-mgt/modals/ApproveRefundModal";
 import { ApproveWithdrawalModal } from "@/src/components/finance-mgt/modals/ApproveWithdrawalModal";
 import { RejectWithdrawalModal } from "@/src/components/finance-mgt/modals/RejectWithdrawalModal";
+import { ReverseWithdrawalModal } from "@/src/components/finance-mgt/modals/ReverseWithdrawalModal";
 import { Button } from "@/src/components/ui/button";
 import { usePermissions } from "@/src/hooks/usePermissions";
 
@@ -162,6 +163,7 @@ const TransactionDetailView = ({ title, backLink, backLinkName }: TransactionDet
     const [isApproveModalOpen, setIsApproveModalOpen] = useState(false);
     const [isWithdrawalApprovalOpen, setIsWithdrawalApprovalOpen] = useState(false);
     const [isWithdrawalRejectionOpen, setIsWithdrawalRejectionOpen] = useState(false);
+    const [isWithdrawalReverseOpen, setIsWithdrawalReverseOpen] = useState(false);
     const params = useParams();
     const id = params?.id;
     const { canManageFinances } = usePermissions();
@@ -193,6 +195,10 @@ const TransactionDetailView = ({ title, backLink, backLinkName }: TransactionDet
     const actionStyle = ACTION_STYLES[data?.action || ""] || "";
     const isPendingApproval = data?.status === "PENDING_APPROVAL";
     const isWithdrawal = data?.transaction_type === "WITHDRAWAL";
+    // Reverse applies to a payout that did NOT settle: stuck awaiting OTP, still
+    // in-flight, or marked successful but failed at the provider.
+    const canReverseWithdrawal =
+        isWithdrawal && ["AWAITING_AUTHORIZATION", "PENDING", "SUCCESSFUL"].includes(data?.status ?? "");
 
     return (
         <>
@@ -277,6 +283,19 @@ const TransactionDetailView = ({ title, backLink, backLinkName }: TransactionDet
                                         >
                                             <Icon icon="mdi:check" className="mr-1" width="16" />
                                             {isWithdrawal ? "Approve Withdrawal" : "Approve Refund"}
+                                        </Button>
+                                    </div>
+                                )}
+
+                                {/* Reverse — for payouts that did not settle (awaiting OTP / in-flight / provider-failed) */}
+                                {canReverseWithdrawal && canManageFinances && (
+                                    <div className="flex items-center gap-2 flex-shrink-0">
+                                        <Button
+                                            onClick={() => setIsWithdrawalReverseOpen(true)}
+                                            className="bg-amber-600 text-white hover:bg-amber-700"
+                                        >
+                                            <Icon icon="mdi:backup-restore" className="mr-1" width="16" />
+                                            Reverse
                                         </Button>
                                     </div>
                                 )}
@@ -414,6 +433,19 @@ const TransactionDetailView = ({ title, backLink, backLinkName }: TransactionDet
                         amount={data.amount}
                         currency={data.currency}
                         walletId={data.wallet_id}
+                    />
+                    <ReverseWithdrawalModal
+                        isOpen={isWithdrawalReverseOpen}
+                        onClose={() => {
+                            setIsWithdrawalReverseOpen(false);
+                            fetchData();
+                        }}
+                        transactionId={data.id}
+                        email={data.user?.email || ""}
+                        amount={data.amount}
+                        currency={data.currency}
+                        walletId={data.wallet_id}
+                        status={data.status}
                     />
                 </>
             )}

--- a/src/components/transactions/TransactionListView.tsx
+++ b/src/components/transactions/TransactionListView.tsx
@@ -18,6 +18,7 @@ import { formatDate, formatMoney } from "@/src/lib/utils";
 import { ApproveRefundModal } from "@/src/components/finance-mgt/modals/ApproveRefundModal";
 import { ApproveWithdrawalModal } from "@/src/components/finance-mgt/modals/ApproveWithdrawalModal";
 import { RejectWithdrawalModal } from "@/src/components/finance-mgt/modals/RejectWithdrawalModal";
+import { ReverseWithdrawalModal } from "@/src/components/finance-mgt/modals/ReverseWithdrawalModal";
 import { usePermissions } from "@/src/hooks/usePermissions";
 
 interface Transaction {
@@ -100,6 +101,7 @@ const TransactionListView = ({ title, description, basePath, apiUrl, filters, re
     const [isWithdrawalApprovalOpen, setIsWithdrawalApprovalOpen] = useState(false);
     const [withdrawalModalInitialStep, setWithdrawalModalInitialStep] = useState<"confirm" | "otp">("confirm");
     const [isWithdrawalRejectionOpen, setIsWithdrawalRejectionOpen] = useState(false);
+    const [isWithdrawalReverseOpen, setIsWithdrawalReverseOpen] = useState(false);
 
     const handleDownload = (type: "CSV" | "PDF") => {
         if (type === "CSV") {
@@ -298,6 +300,27 @@ const TransactionListView = ({ title, description, basePath, apiUrl, filters, re
                 },
             });
         }
+    }
+
+    // Reverse a withdrawal that did NOT pay out — payout stuck awaiting OTP, still
+    // in-flight (PENDING), or marked successful but failed at the provider. Refunds
+    // amount + fee to the user's wallet.
+    if (
+        canManageFinances &&
+        selectedRow !== null &&
+        data[selectedRow]?.transaction_type === "WITHDRAWAL" &&
+        ["AWAITING_AUTHORIZATION", "PENDING", "SUCCESSFUL"].includes(data[selectedRow]?.status ?? "")
+    ) {
+        const tx = data[selectedRow];
+        detailButtons.push({
+            label: "Reverse Withdrawal",
+            Icon: <Icon icon="mdi:backup-restore" />,
+            onClick: () => {
+                setSelectedTxForApproval(tx);
+                setIsWithdrawalReverseOpen(true);
+                setSelectedRow(null);
+            },
+        });
     }
 
     return (
@@ -638,6 +661,23 @@ const TransactionListView = ({ title, description, basePath, apiUrl, filters, re
                     amount={selectedTxForApproval.amount}
                     currency={selectedTxForApproval.currency}
                     walletId={String(selectedTxForApproval.wallet_id || "")}
+                />
+            )}
+
+            {selectedTxForApproval && selectedTxForApproval.transaction_type === "WITHDRAWAL" && (
+                <ReverseWithdrawalModal
+                    isOpen={isWithdrawalReverseOpen}
+                    onClose={() => {
+                        setIsWithdrawalReverseOpen(false);
+                        setSelectedTxForApproval(null);
+                        fetchTransactions();
+                    }}
+                    transactionId={selectedTxForApproval.id}
+                    email={selectedTxForApproval.user?.email || selectedTxForApproval.customer_email || selectedTxForApproval.customerEmail || ""}
+                    amount={selectedTxForApproval.amount}
+                    currency={selectedTxForApproval.currency}
+                    walletId={String(selectedTxForApproval.wallet_id || "")}
+                    status={selectedTxForApproval.status}
                 />
             )}
         </div>

--- a/src/lib/request-handlers/financeMgt.ts
+++ b/src/lib/request-handlers/financeMgt.ts
@@ -103,6 +103,28 @@ export function RejectWithdrawal() {
     });
 }
 
+export interface ReverseWithdrawalPayload {
+    transaction_id: string;
+    reason: string;
+    skip_provider_check: boolean;
+}
+
+// Reverse a withdrawal that did NOT pay out (AWAITING_AUTHORIZATION / PENDING /
+// SUCCESSFUL). Refunds amount + fee. By default the backend verifies the payout
+// did not settle with the provider; skip_provider_check bypasses that guard for
+// incidents already confirmed with the provider.
+export function ReverseWithdrawal() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ walletId, payload }: { walletId: string, payload: ReverseWithdrawalPayload }) =>
+            axiosRequest.post(API_ROUTES.wallet.reverseWithdrawal(walletId), payload),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: [FinanceRequestKeys.getAllTransactions] });
+            queryClient.invalidateQueries({ queryKey: [FinanceRequestKeys.getTransactionDetails] });
+        },
+    });
+}
+
 export function AuthorizeDisbursement() {
     const queryClient = useQueryClient();
     return useMutation({

--- a/src/lib/routes/endpoints.tsx
+++ b/src/lib/routes/endpoints.tsx
@@ -136,6 +136,7 @@ export const API_ROUTES = {
         withdraw: (id: string) => `/wallets/${id}/withdraw`,
         approveWithdrawal: (id: string | number) => `/wallets/${id}/approve-withdrawal`,
         rejectWithdrawal: (id: string | number) => `/wallets/${id}/reject-withdrawal`,
+        reverseWithdrawal: (id: string | number) => `/wallets/${id}/reverse-withdrawal`,
         authorizeDisbursement: (id: string | number) => `/wallets/${id}/authorize-disbursement`,
         resendDisbursementOtp: (id: string | number) => `/wallets/${id}/resend-disbursement-otp`,
         pendingWithdrawals: '/wallets/pending-withdrawals',


### PR DESCRIPTION
## Context
Pairs with api-v1 #126. The backend added `POST /wallets/{id}/reverse-withdrawal` to recover withdrawals that were debited but never paid out (provider-failed, or OTP-expired). This exposes it in the admin dashboard.

## What this does
- **`reverseWithdrawal`** endpoint in `endpoints.tsx` + **`ReverseWithdrawal()`** React Query hook in `financeMgt.ts` (invalidates transaction queries on success).
- **`ReverseWithdrawalModal`** — required reason (min 3 chars) + a "skip provider verification" checkbox with warning copy (only when ops has confirmed the payout won't settle).
- **"Reverse Withdrawal"** action wired into `TransactionListView` (row context menu) and `TransactionDetailView` (header button), shown for withdrawals in `AWAITING_AUTHORIZATION` / `PENDING` / `SUCCESSFUL`.

## Verification
- `tsc --noEmit` passes clean.

> Requires api-v1 #126 deployed for the endpoint to exist.