### PR TITLE
feat(reports): add Agent Reporting Suite UI and API integration

### DIFF
--- a/src/components/reports-mgt/BookingReportsTab.tsx
+++ b/src/components/reports-mgt/BookingReportsTab.tsx
@@ -36,7 +36,10 @@ export default function BookingReportsTab() {
             if (status) queryParams.append("status", status);
             if (paymentMethod) queryParams.append("payment_method", paymentMethod);
             
-            const url = `${API_ROUTES.reports.bookings.export}?${queryParams.toString()}`;
+            const baseUrl = user?.role === 'AGENT' 
+                ? API_ROUTES.agents.bookings.export 
+                : API_ROUTES.reports.bookings.export;
+            const url = `${baseUrl}?${queryParams.toString()}`;
             
             await requestReportDownload(url, formatType);
             toast.success(`${formatType.toUpperCase()} export generated successfully`);
@@ -135,7 +138,7 @@ export default function BookingReportsTab() {
                         disabled={!!exportingFormat}
                         className="flex items-center gap-2 px-4 py-2 bg-white border border-red-200 text-red-700 rounded-md shadow-sm hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 transition-colors text-sm font-medium"
                     >
-                        {exportingFormat === 'pdf' ? <Spinner className="w-4 h-4 text-red-700" /> : <FiDownload className="w-4 h-4" />}
+                        {exportingFormat === 'pdf' ? <Spinner width="16" height="16" color="#b91c1c" /> : <FiDownload className="w-4 h-4" />}
                         Export to PDF
                     </button>
                     
@@ -144,7 +147,7 @@ export default function BookingReportsTab() {
                         disabled={!!exportingFormat}
                         className="flex items-center gap-2 px-4 py-2 bg-white border border-green-200 text-green-700 rounded-md shadow-sm hover:bg-green-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:opacity-50 transition-colors text-sm font-medium"
                     >
-                        {exportingFormat === 'csv' ? <Spinner className="w-4 h-4 text-green-700" /> : <FiDownload className="w-4 h-4" />}
+                        {exportingFormat === 'csv' ? <Spinner width="16" height="16" color="#15803d" /> : <FiDownload className="w-4 h-4" />}
                         Export to CSV
                     </button>
                     
@@ -153,7 +156,7 @@ export default function BookingReportsTab() {
                         disabled={!!exportingFormat}
                         className="flex items-center gap-2 px-4 py-2 bg-white border border-blue-200 text-blue-700 rounded-md shadow-sm hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 transition-colors text-sm font-medium"
                     >
-                        {exportingFormat === 'xlsx' ? <Spinner className="w-4 h-4 text-blue-700" /> : <FiDownload className="w-4 h-4" />}
+                        {exportingFormat === 'xlsx' ? <Spinner width="16" height="16" color="#1d4ed8" /> : <FiDownload className="w-4 h-4" />}
                         Export to Excel (.xlsx)
                     </button>
                 </div>

--- a/src/components/reports-mgt/HistoryTab.tsx
+++ b/src/components/reports-mgt/HistoryTab.tsx
@@ -7,6 +7,7 @@ import toast from "react-hot-toast";
 import { FiDownload, FiExternalLink } from "react-icons/fi";
 import { format } from "date-fns";
 import TablePagination from "@/src/components/TablePagination";
+import { useAuth } from "@/src/hooks/useAuth";
 import Spinner from "@/src/components/ui/Spinner";
 
 interface IStatement {
@@ -21,7 +22,11 @@ interface IStatement {
 }
 
 export default function HistoryTab() {
-    const { data: statementsData, isLoading, error } = GetStatements();
+    const { user } = useAuth();
+    const isAgent = user?.role === 'AGENT';
+    const userType = isAgent ? 'agent' : 'owner';
+
+    const { data: statementsData, isLoading, error } = GetStatements(userType, user?.id?.toString());
     const statements: IStatement[] = statementsData?.data?.data || [];
 
     const [downloadingId, setDownloadingId] = useState<string | null>(null);
@@ -42,7 +47,9 @@ export default function HistoryTab() {
         const id = `${year}-${month}-${formatType}`;
         try {
             setDownloadingId(id);
-            const url = API_ROUTES.reports.statements.download(year, month);
+            const url = isAgent 
+                ? API_ROUTES.agents.statements.download(user!.id.toString(), year, month)
+                : API_ROUTES.reports.statements.download(year, month);
 
             await requestReportDownload(url, formatType);
             toast.success(`${formatType.toUpperCase()} downloaded successfully`);
@@ -69,7 +76,7 @@ export default function HistoryTab() {
 
                 {isLoading ? (
                     <div className="flex justify-center py-10">
-                        <Spinner className="w-8 h-8 text-primary" />
+                        <Spinner width="32" height="32" color="#124452" />
                     </div>
                 ) : error ? (
                     <div className="text-red-500 py-4">Failed to load history. Please try again later.</div>
@@ -107,27 +114,19 @@ export default function HistoryTab() {
                                                     <div className="flex items-center justify-end gap-3">
                                                         <button
                                                             onClick={() => handleDownload(stmt.year, stmt.month, 'pdf')}
+                                                            className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-red-600 bg-red-50 hover:bg-red-100 rounded-md transition-colors"
                                                             disabled={downloadingId === `${stmt.year}-${stmt.month}-pdf`}
-                                                            className="flex items-center gap-1.5 text-primary hover:text-primary/80 disabled:opacity-50 text-sm font-medium transition-colors"
                                                         >
-                                                            {downloadingId === `${stmt.year}-${stmt.month}-pdf` ? (
-                                                                <Spinner className="w-4 h-4" />
-                                                            ) : (
-                                                                <FiDownload className="w-4 h-4" />
-                                                            )}
+                                                            {downloadingId === `${stmt.year}-${stmt.month}-pdf` ? <Spinner width="16" height="16" color="#b91c1c" /> : <FiDownload />}
                                                             PDF
                                                         </button>
                                                         <span className="text-gray-300">|</span>
                                                         <button
                                                             onClick={() => handleDownload(stmt.year, stmt.month, 'csv')}
+                                                            className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-primary bg-primary/10 hover:bg-primary/20 rounded-md transition-colors"
                                                             disabled={downloadingId === `${stmt.year}-${stmt.month}-csv`}
-                                                            className="flex items-center gap-1.5 text-primary hover:text-primary/80 disabled:opacity-50 text-sm font-medium transition-colors"
                                                         >
-                                                            {downloadingId === `${stmt.year}-${stmt.month}-csv` ? (
-                                                                <Spinner className="w-4 h-4" />
-                                                            ) : (
-                                                                <FiDownload className="w-4 h-4" />
-                                                            )}
+                                                            {downloadingId === `${stmt.year}-${stmt.month}-csv` ? <Spinner width="16" height="16" color="#124452" /> : <FiDownload />}
                                                             CSV
                                                         </button>
                                                         {stmt.google_cloud_link && (
@@ -161,13 +160,10 @@ export default function HistoryTab() {
 
                         {statements.length > 0 && (
                             <TablePagination
-                                component="div"
-                                count={statements.length}
-                                page={page}
-                                onPageChange={handleChangePage}
-                                rowsPerPage={rowsPerPage}
-                                onRowsPerPageChange={handleChangeRowsPerPage}
-                                rowsPerPageOptions={[10, 25, 50]}
+                                total={statements.length}
+                                itemsPerPage={rowsPerPage}
+                                currentPage={page + 1}
+                                setPage={(newPage) => setPage(newPage - 1)}
                             />
                         )}
                     </div>

--- a/src/lib/request-handlers/reportsMgt.ts
+++ b/src/lib/request-handlers/reportsMgt.ts
@@ -6,10 +6,16 @@ export enum ReportsRequestKeys {
     statements = "getStatements",
 }
 
-export function GetStatements() {
+export function GetStatements(userType: 'owner' | 'agent' = 'owner', agentId?: string) {
     return useQuery({
-        queryKey: [ReportsRequestKeys.statements],
-        queryFn: () => axiosRequest.get(API_ROUTES.reports.statements.base),
+        queryKey: [ReportsRequestKeys.statements, userType, agentId],
+        queryFn: () => {
+            const url = userType === 'agent' && agentId 
+                ? API_ROUTES.agents.statements.base(agentId)
+                : API_ROUTES.reports.statements.base;
+            return axiosRequest.get(url);
+        },
+        enabled: userType === 'owner' || !!agentId,
         refetchOnWindowFocus: true,
     });
 }

--- a/src/lib/routes/endpoints.tsx
+++ b/src/lib/routes/endpoints.tsx
@@ -201,6 +201,15 @@ export const API_ROUTES = {
             export: '/reports/bookings/export',
         }
     },
+    agents: {
+        statements: {
+            base: (agentId: string) => `/reports/agents/${agentId}/statements`,
+            download: (agentId: string, year: string | number, month: string | number) => `/reports/agents/${agentId}/statements/${year}/${month}/download`,
+        },
+        bookings: {
+            export: '/reports/agents/bookings/export',
+        }
+    },
     ical: {
         units: {
             outbound: (unitId: string | number) => `/ical/units/${unitId}/outbound`,

--- a/src/lib/routes/nav_links.tsx
+++ b/src/lib/routes/nav_links.tsx
@@ -285,7 +285,7 @@ export const NAV_LINKS: ILink[] = [
         pathName: 'reports',
         link: PAGE_ROUTES.dashboard.reports.agentPerformance,
         icon: <FinancialsIcon className={"w-5"} color={"white"} />,
-        allow: [UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.OPERATIONS_ADMIN, UserRole.ANALYST, UserRole.OWNER],
+        allow: [UserRole.ADMIN, UserRole.SUPER_ADMIN, UserRole.OPERATIONS_ADMIN, UserRole.ANALYST, UserRole.OWNER, UserRole.AGENT],
         secondary: true,
         children: [
             {
@@ -298,7 +298,7 @@ export const NAV_LINKS: ILink[] = [
                 name: 'Statements',
                 pathName: 'statements',
                 link: PAGE_ROUTES.dashboard.reports.statements,
-                allow: [UserRole.OWNER, UserRole.ADMIN, UserRole.SUPER_ADMIN],
+                allow: [UserRole.OWNER, UserRole.AGENT, UserRole.ADMIN, UserRole.SUPER_ADMIN],
             },
         ]
     },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -64,6 +64,78 @@ export interface IReferralInfo {
   link: string;
 }
 
+export interface MonthlyStatementData {
+  owner_id: string;
+  year: number;
+  month: number;
+  properties_count: number;
+  total_bookings: number;
+  total_nights: number;
+  gross_revenue: number;
+  platform_fees: number;
+  agent_fees: number;
+  net_earnings: number;
+  bookings: any[];
+}
+
+export interface AgentBookingReportItem {
+  booking_id: string;
+  property_name: string;
+  unit_name: string;
+  owner_name: string;
+  guest_name: string;
+  start_date: string;
+  end_date: string;
+  created_at: string;
+  nights: number;
+  guests: number;
+  status: string;
+  payment_method?: string;
+  gross_amount: number;
+  caution_fee: number;
+  agent_fee: number;
+  caution_refunded: string;
+}
+
+export interface AgentPropertyBreakdown {
+  property_name: string;
+  owner_name: string;
+  total_bookings: number;
+  nights_booked: number;
+  gross_revenue: number;
+  agent_commissions_earned: number;
+}
+
+export interface AgentFinancialSummary {
+  agent_id: string;
+  agent_name: string;
+  agent_email: string;
+  year: number;
+  month: number;
+  properties_count: number;
+  total_bookings: number;
+  nights_booked: number;
+  total_gross_amount: number;
+  total_caution_fees: number;
+  total_agent_fees: number;
+  excluded_non_ngn_count: number;
+  per_property_breakdown: AgentPropertyBreakdown[];
+  bookings: AgentBookingReportItem[];
+}
+
+export interface AgentAdHocReportSummary {
+  requested_by: string;
+  report_type: string;
+  date_range: string;
+  total_bookings: number;
+  nights_booked: number;
+  total_gross_amount: number;
+  total_caution_fees: number;
+  total_agent_fees: number;
+  excluded_non_ngn_count: number;
+  bookings: AgentBookingReportItem[];
+}
+
 export interface IAgentReferralStats {
   total_referrals: number;
   active_referrals: number;


### PR DESCRIPTION
### Summary
Implements the frontend integration for the Agent Reporting Suite, mirroring the newly shipped backend agent reporting endpoints. Existing Owner reporting components have been refactored for reuse rather than duplicated, keeping the codebase DRY.

---

### Changes

#### `src/lib/types.ts`
- Added TypeScript interfaces for agent report schemas:
  - `AgentFinancialSummary`
  - `AgentBookingReportItem`
  - `AgentPropertyBreakdown`
  - `AgentAdHocReportSummary`

#### `src/lib/routes/endpoints.tsx`
- Registered new agent reporting API routes under `API_ROUTES.agents`:
  - `GET /agents/{agent_id}/statements`
  - `GET /agents/{agent_id}/statements/{year}/{month}/download`
  - `GET /agents/bookings/export`

#### `src/lib/request-handlers/reportsMgt.ts`
- Parameterized `GetStatements` to accept `userType: 'owner' | 'agent'` and an optional `agentId`.
- Dynamically resolves the correct endpoint based on the caller's role.

#### `src/components/reports-mgt/HistoryTab.tsx`
- Reads `user.role` via `useAuth` to detect agent sessions.
- Routes statement list fetches and downloads to agent endpoints when applicable.
- Fixed pre-existing TS errors: `TablePagination` props alignment and `Spinner` attribute types.

#### `src/components/reports-mgt/BookingReportsTab.tsx`
- Routes ad-hoc booking export requests to `API_ROUTES.agents.bookings.export` for agents and `API_ROUTES.reports.bookings.export` for owners/admins.
- Fixed pre-existing TS errors: `Spinner` `className` → `width`/`height`/`color` props.

#### `src/lib/routes/nav_links.tsx`
- Added `UserRole.AGENT` to the allow list for the `Reports` nav group and the `Statements` child route.